### PR TITLE
Add maintenance issues endpoints and schemas to OpenAPI specification

### DIFF
--- a/components/maintenance_issue.yaml
+++ b/components/maintenance_issue.yaml
@@ -1,0 +1,46 @@
+type: object
+description: A single maintenance issue or task
+required: ["id", "title", "status", "created_at"]
+properties:
+  id:
+    type: string
+    description: Unique identifier for the issue
+    example: "MAINT-2024-001"
+    x-faker: random.uuid
+  created_at:
+    type: string
+    format: date-time
+    description: When the issue was created
+    example: "2024-02-03T16:28:00Z"
+    x-faker: date.recent
+  title:
+    type: string
+    description: Title/description of the issue
+    example: "Oil leak in Turbine 2"
+    x-faker: lorem.sentence
+  station_group:
+    $ref: "#/components/schemas/group"
+  # area:
+  #   type: object
+  #   properties:
+  #     code:
+  #       type: string
+  #       enum: ["HEG", "REIN", "GOV", "DAJ"]
+  #       description: Area code
+  #       example: "HEG"
+  #     name:
+  #       type: string
+  #       description: Full name of the area
+  #       example: "Heggmoen Power Station"
+  status:
+    $ref: "#/components/schemas/maintenance_status"
+  requires_callout:
+    type: boolean
+    description: Whether this issue requires on-site personnel
+    example: true
+    x-faker: datatype.boolean
+  responsible:
+    type: string
+    description: Name of the person responsible for the issue
+    example: "Tor Osaurus"
+    x-faker: name.fullName 

--- a/components/maintenance_status.yaml
+++ b/components/maintenance_status.yaml
@@ -1,0 +1,14 @@
+type: string
+enum:
+  - registered
+  - planned
+  - closed
+x-faker:
+  helpers.arrayElement:
+    [
+      [
+        "registered",
+        "planned",
+        "closed",
+      ],
+    ] 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -32,6 +32,10 @@ components:
       $ref: "./components/monetary_value.yaml"
     bypass_system:
       $ref: "./components/bypass_system.yaml"
+    maintenance_issue:
+      $ref: "./components/maintenance_issue.yaml"
+    maintenance_status:
+      $ref: "./components/maintenance_status.yaml"
 
 paths:
   /overview:
@@ -267,3 +271,69 @@ paths:
                   message:
                     type: string
                     example: "Bypass system not found"
+
+  /maintenance-issues:
+    get:
+      summary: Get a list of maintenance issues
+      description: Returns a list of maintenance issues and tasks that can be filtered by various criteria
+      parameters:
+        - in: query
+          name: status
+          required: false
+          schema:
+            $ref: "#/components/schemas/maintenance_status"
+          description: Filter issues by status
+        - in: query
+          name: start_date
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Filter issues created on or after this date (e.g., "2024-01-01")
+        - in: query
+          name: end_date
+          required: false
+          schema:
+            type: string
+            format: date
+          description: Filter issues created before this date (e.g., "2024-02-01")
+      responses:
+        "200":
+          description: List of maintenance issues matching the filter criteria
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/maintenance_issue"
+
+  /maintenance-issues/{id}:
+    get:
+      summary: Get a specific maintenance issue by id
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: string
+            description: The unique identifier of the maintenance issue
+            x-faker:
+              helpers.replaceSymbols: "??#.??#.??#"
+      responses:
+        "200":
+          description: A single maintenance issue
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/maintenance_issue"
+        "404":
+          description: Maintenance issue not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: "Maintenance issue not found"


### PR DESCRIPTION
- Introduced new schemas for maintenance_issue and maintenance_status
- Added GET endpoints to retrieve maintenance issues list and individual issue details
- Included filtering options for maintenance issues by status and date range