### PR TITLE
Add name property to bypass system schema

### DIFF
--- a/components/bypass_system.yaml
+++ b/components/bypass_system.yaml
@@ -7,6 +7,11 @@ properties:
     x-faker:
       helpers.replaceSymbols: "??#.??#.??#" # RDS PS Format
     example: "BP1.CD2.EF3"
+  name:
+    type: string
+    description: Name of the bypass system.
+    example: StationMan
+    x-faker: animal.bear
   related_component:
     type: object
     description: The related component, either a magazine or a station.


### PR DESCRIPTION
- Introduced a new 'name' property to the bypass system schema
- Added description and example for the name field
- Used x-faker for generating example bear names