### PR TITLE
Refactor magazine history schema to use simple reading float references

### DIFF
--- a/components/magazine_history.yaml
+++ b/components/magazine_history.yaml
@@ -18,39 +18,15 @@ properties:
           format: date-time
           x-faker: date.past
           example: "2023-10-01T14:00:00Z"
+        current_level_elevation_MASL:
+          type: object
+          description: Current storage level as elevation MASL (metres above sea level).
+          $ref: "#/components/schemas/simple_reading_float"
         storage_percentage:
-          type: number
-          format: float
-          description: Storage level at the given timestamp (as a percentage)
-          x-faker:
-            datatype.float:
-              min: 0.0
-              max: 100.0
-          example: 75.0
+          $ref: "#/components/schemas/simple_reading_float"
         inflow_rate_liters_per_sec:
-          type: number
-          format: float
-          description: Inflow rate in liters per second
-          x-faker:
-            datatype.float:
-              min: 0.0
-              max: 1000.0
-          example: 500.0
+          $ref: "#/components/schemas/simple_reading_float"
         outflow_rate_liters_per_sec:
-          type: number
-          format: float
-          description: Outflow rate in liters per second
-          x-faker:
-            datatype.float:
-              min: 0.0
-              max: 1000.0
-          example: 450.0
+          $ref: "#/components/schemas/simple_reading_float"
         deviation_percentage:
-          type: number
-          format: float
-          description: Deviation from normal capacity as a percentage
-          x-faker:
-            datatype.float:
-              min: -30.0
-              max: 30.0
-          example: 5.0
+          $ref: "#/components/schemas/simple_reading_float"

--- a/components/reading_float.yaml
+++ b/components/reading_float.yaml
@@ -1,7 +1,7 @@
 # reading in mw
 
 type: object
-description: Float reading from industrial equiptment with source health information. Type of float is indictated by parten propertie (Gw, Gwh, MASL etc.)
+description: Float reading from industrial equiptment with source health information. Type of float is indictated by parent propertie (Gw, Gwh, MASL etc.)
 required: ["value", "last_update_from_source", "source_is_alive"]
 properties:
   value:
@@ -16,7 +16,7 @@ properties:
   last_update_from_source:
     type: string
     format: date-time
-    description: Timestamp of last update from the source system
+    description: Timestamp of last update from the source system (so we can evaluate if the source is alive)
     x-faker: date.recent
     example: "2024-03-14T15:30:00Z"
   source_is_alive:

--- a/components/simple_reading_float.yaml
+++ b/components/simple_reading_float.yaml
@@ -1,0 +1,16 @@
+# reading in mw
+
+type: object
+description: A simple float reading from industrial equiptment. Type of float is indictated by parent properties (Gw, Gwh, MASL etc.)
+required: ["value"]
+properties:
+  value:
+    type: number
+    format: float
+    description: A given reading as float
+    x-faker:
+      datatype.float:
+        min: 0
+        max: 500
+    example: 245.5
+additionalProperties: false


### PR DESCRIPTION
- Updated magazine history schema to use `simple_reading_float` references for numeric properties
- Simplified schema by removing inline float definitions
- Added new `current_level_elevation_MASL` property using reference structure